### PR TITLE
Control packet metrics calculations via env var

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -264,7 +264,9 @@ export async function postBlockPacketHook(ctx: Context, entities: Entities) {
   packetUpdates = await processAndUpsertPackets(entities.acknowledgements, ctx, ackPacketHook);
   packetUpdates.forEach(id => uniquePacketIds.add(id));
 
-  await packetMetrics(Array.from(uniquePacketIds), ctx);
+  if (process.env.CALC_PACKET_METRICS === 'true') {
+    await packetMetrics(Array.from(uniquePacketIds), ctx);
+  }
 }
 
 async function upsertNewEntities(ctx: Context, entities: Entities) {


### PR DESCRIPTION
The packet metrics can slow down the regular indexers significantly. The backfill indexer will fill out the packet metrics with some delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable option to toggle packet metrics calculation on or off based on an environment variable, enhancing flexibility in the packet handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->