### PR TITLE
Fixed migration bug and changed sendPacket to track first fee instead…

### DIFF
--- a/db/migrations/1723836233391-Data.js
+++ b/db/migrations/1723836233391-Data.js
@@ -7,8 +7,8 @@ module.exports = class Data1723836233391 {
         await db.query(`DROP INDEX "public"."IDX_9415c52ccc157e1a37c9f3f623"`)
         await db.query(`ALTER TABLE "send_packet_fee_deposited" RENAME COLUMN "send_gas_limit" TO "recv_gas_limit"`);
         await db.query(`ALTER TABLE "send_packet_fee_deposited" RENAME COLUMN "send_gas_price" TO "recv_gas_price"`);
-        await db.query(`ALTER TABLE "send_packet" ADD "total_recv_fees_deposited" numeric NOT NULL`)
-        await db.query(`ALTER TABLE "send_packet" ADD "total_ack_fees_deposited" numeric NOT NULL`)
+        await db.query(`ALTER TABLE "send_packet" ADD "total_recv_fees_deposited" numeric`)
+        await db.query(`ALTER TABLE "send_packet" ADD "total_ack_fees_deposited" numeric`)
         await db.query(`ALTER TABLE "send_packet_fee_deposited" DROP CONSTRAINT "FK_9415c52ccc157e1a37c9f3f6235"`)
         await db.query(`ALTER TABLE "send_packet_fee_deposited" ADD CONSTRAINT "UQ_9415c52ccc157e1a37c9f3f6235" UNIQUE ("send_packet_id")`)
         await db.query(`CREATE INDEX "IDX_2c83d97c2235020f49a5b6b03d" ON "send_packet_fee_deposited" ("recv_gas_limit") `)

--- a/schema.graphql
+++ b/schema.graphql
@@ -53,9 +53,9 @@ type SendPacket @entity {
     polymerGas: Int
     polymerBlockNumber: BigInt
 
-    totalRecvFeesDeposited: BigInt! @index
-    totalAckFeesDeposited: BigInt! @index
-    lastFeeDeposited: SendPacketFeeDeposited @derivedFrom(field: "sendPacket")
+    totalRecvFeesDeposited: BigInt @index
+    totalAckFeesDeposited: BigInt @index
+    firstFeeDeposited: SendPacketFeeDeposited @derivedFrom(field: "sendPacket")
     feesDeposited: [SendPacketFeeDeposited!] @derivedFrom(field: "sendPacket")
 }
 

--- a/src/handlers/backfill.ts
+++ b/src/handlers/backfill.ts
@@ -163,9 +163,13 @@ async function updateMissingSendPacketFees(ctx: Context) {
         }
       });
     if (sendPacket) {
-      sendPacket.totalRecvFeesDeposited = sendPacket.totalRecvFeesDeposited + BigInt(sendPacketFee.recvGasLimit * sendPacketFee.recvGasPrice);
-      sendPacket.totalAckFeesDeposited = sendPacket.totalAckFeesDeposited + BigInt(sendPacketFee.ackGasLimit * sendPacketFee.ackGasPrice);
-      sendPacket.lastFeeDeposited = sendPacketFee;
+      const currRecvFeesDeposited = sendPacket.totalRecvFeesDeposited ? sendPacket.totalRecvFeesDeposited : BigInt(0);
+      sendPacket.totalRecvFeesDeposited = currRecvFeesDeposited + BigInt(sendPacketFee.recvGasLimit * sendPacketFee.recvGasPrice);
+      const currAckFeesDeposited = sendPacket.totalAckFeesDeposited ? sendPacket.totalAckFeesDeposited : BigInt(0);
+      sendPacket.totalAckFeesDeposited = currAckFeesDeposited + BigInt(sendPacketFee.ackGasLimit * sendPacketFee.ackGasPrice);
+      if (!sendPacket.firstFeeDeposited) {
+        sendPacket.firstFeeDeposited = sendPacketFee;
+      }
       if (!sendPacket.feesDeposited) {
         sendPacket.feesDeposited = [sendPacketFee];
       } else {

--- a/src/model/generated/sendPacket.model.ts
+++ b/src/model/generated/sendPacket.model.ts
@@ -96,15 +96,15 @@ export class SendPacket {
     polymerBlockNumber!: bigint | undefined | null
 
     @Index_()
-    @BigIntColumn_({nullable: false})
-    totalRecvFeesDeposited!: bigint
+    @BigIntColumn_({nullable: true})
+    totalRecvFeesDeposited!: bigint | undefined | null
 
     @Index_()
-    @BigIntColumn_({nullable: false})
-    totalAckFeesDeposited!: bigint
+    @BigIntColumn_({nullable: true})
+    totalAckFeesDeposited!: bigint | undefined | null
 
     @OneToOne_(() => SendPacketFeeDeposited, e => e.sendPacket)
-    lastFeeDeposited!: SendPacketFeeDeposited | undefined | null
+    firstFeeDeposited!: SendPacketFeeDeposited | undefined | null
 
     @OneToMany_(() => SendPacketFeeDeposited, e => e.sendPacket)
     feesDeposited!: SendPacketFeeDeposited[]


### PR DESCRIPTION
Fixed migration file issue and updated sendPackets to track first fee instead of last

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of fee deposits for the `sendPacket` object, allowing greater flexibility in data representation.
  - Introduced a new property `firstFeeDeposited` to track the first fee deposited.

- **Bug Fixes**
  - Improved calculation logic for total fees by ensuring proper initialization of values.

- **Refactor**
  - Updated field definitions in the GraphQL schema to allow nullable values for `totalRecvFeesDeposited` and `totalAckFeesDeposited`.
  - Renamed `lastFeeDeposited` to `firstFeeDeposited` for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->